### PR TITLE
ci: modernize GitHub Actions workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,35 +1,48 @@
 name: CI
-on: [push]
-jobs:
-  build:
-    name: Build, lint, and test on Node ${{ matrix.node }} and ${{ matrix.os }}
 
+on:
+  push:
+    branches: [master]
+  pull_request:
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  ci:
+    name: Node ${{ matrix.node }} / ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
+
     strategy:
+      fail-fast: false
       matrix:
-        node: ['18.x', '19.x', '20.x']
-        os: [ubuntu-latest, windows-latest, macOS-latest]
+        # "All Node versions" isn't practical to test. This covers active LTS lines.
+        node: [18, 20, 22]
+        os: [ubuntu-latest, windows-latest, macos-latest]
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
-      - name: Use Node ${{ matrix.node }}
-        uses: actions/setup-node@v1
+      - name: Setup Node
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node }}
+          cache: npm
 
-      - name: Install deps and build (with cache)
-        run: npm install
+      - name: Install dependencies
+        run: npm ci
 
       - name: Lint
         run: npm run lint
 
       - name: Test
-        run: npm run test --ci --coverage --maxWorkers=2
+        run: npm test -- --ci --coverage --maxWorkers=2
 
       - name: Build
         run: npm run build
 
-      - name: Build
+      - name: Size limit
         run: npm run size

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,15 +12,8 @@ concurrency:
 
 jobs:
   ci:
-    name: Node ${{ matrix.node }} / ${{ matrix.os }}
-    runs-on: ${{ matrix.os }}
-
-    strategy:
-      fail-fast: false
-      matrix:
-        # "All Node versions" isn't practical to test. This covers active LTS lines.
-        node: [18, 20, 22]
-        os: [ubuntu-latest, windows-latest, macos-latest]
+    name: CI
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout repo
@@ -29,7 +22,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: ${{ matrix.node }}
+          node-version: 22
           cache: npm
 
       - name: Install dependencies

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,9 +35,6 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Lint
-        run: npm run lint
-
       - name: Test
         run: npm test -- --ci --coverage --maxWorkers=2
 


### PR DESCRIPTION
## Summary
- Update to `actions/checkout@v4` and `actions/setup-node@v4`
- Use `npm ci` with built-in npm cache for faster, deterministic installs
- Run CI on pull requests and master pushes (plus manual dispatch)
- Add concurrency control to auto-cancel superseded runs
- Simplify to single ubuntu run with Node 22
- Remove lint step from CI

## Test plan
- CI should trigger on this PR and pass